### PR TITLE
Stats

### DIFF
--- a/lib/strd/links.ex
+++ b/lib/strd/links.ex
@@ -100,6 +100,15 @@ defmodule Strd.Links do
     end
   end
 
+  @doc """
+  Increments the view_count of a given Link by num
+  """
+  @spec increase_view_count(Link.t(), integer()) :: {integer(), [any()]}
+  def increase_view_count(%Link{short: short_url}, num \\ 1) when short_url != nil do
+    from(l in Link, where: l.short == ^short_url, select: l.view_count)
+    |> Repo.update_all(inc: [view_count: num])
+  end
+
   defp generate_short_url() do
     # Not guaranteed to be unique!  This just generates a random
     # cryptographically secure string 6 characters long

--- a/lib/strd/links.ex
+++ b/lib/strd/links.ex
@@ -22,6 +22,7 @@ defmodule Strd.Links do
       ** (Ecto.NoResultsError)
 
   """
+  @spec get_link!(integer()) :: Link.t()
   def get_link!(id), do: Repo.get!(Link, id)
 
   @doc """
@@ -38,6 +39,7 @@ defmodule Strd.Links do
       ** (Ecto.NoResultsError)
 
   """
+  @spec get_by_short_url!(String.t()) :: Link.t()
   def get_by_short_url!(short_url), do: Repo.get_by!(Link, short: short_url)
 
   @doc """
@@ -103,8 +105,8 @@ defmodule Strd.Links do
   @doc """
   Increments the view_count of a given Link by num
   """
-  @spec increase_view_count(Link.t(), integer()) :: {integer(), [any()]}
-  def increase_view_count(%Link{short: short_url}, num \\ 1) when short_url != nil do
+  @spec increase_view_count(String.t(), integer()) :: {integer(), [any()]}
+  def increase_view_count(short_url, num \\ 1) when short_url != nil do
     from(l in Link, where: l.short == ^short_url, select: l.view_count)
     |> Repo.update_all(inc: [view_count: num])
   end

--- a/lib/strd/links/link.ex
+++ b/lib/strd/links/link.ex
@@ -5,6 +5,7 @@ defmodule Strd.Links.Link do
   schema "links" do
     field :original, :string
     field :short, :string
+    field :view_count, :integer, default: 0
 
     timestamps()
   end
@@ -13,17 +14,18 @@ defmodule Strd.Links.Link do
 
   @doc false
   def new_changeset(link, attrs) do
-    cast(link, attrs, [:original, :short])
+    cast(link, attrs, [:original, :short, :view_count])
   end
 
   @doc false
   def changeset(link, attrs) do
     link
-    |> cast(attrs, [:original, :short])
+    |> cast(attrs, [:original, :short, :view_count])
     |> validate_required([:original, :short])
     |> validate_length(:short, min: 3)
     |> validate_url(:original)
     |> validate_url(:short)
+    |> validate_number(:view_count, min: 0)
     |> unique_constraint(:short)
   end
 

--- a/lib/strd/telemetry/view_count_reporter.ex
+++ b/lib/strd/telemetry/view_count_reporter.ex
@@ -1,0 +1,41 @@
+defmodule Strd.Telemetry.ViewCountReporter do
+  @moduledoc """
+  """
+  use GenServer
+  require Logger
+  alias Strd.Links
+
+  @metric_event_name [:links, :short]
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, nil)
+  end
+
+  @impl true
+  def init(_initial_state) do
+    Process.flag(:trap_exit, true)
+
+    :ok =
+      :telemetry.attach(
+        "strd-telemetry-view-count-metric",
+        @metric_event_name,
+        &handle_event/4,
+        nil
+      )
+
+    {:ok, nil}
+  end
+
+  @impl true
+  def terminate(_, _state) do
+    :telemetry.detach({__MODULE__, @metric_event_name, self()})
+  end
+
+  defp handle_event(_event_name, %{views: views}, %{short_url: short_url}, _config) do
+    {_, [total_view]} = Links.increase_view_count(short_url, views)
+
+    Logger.info(
+      "Short link #{short_url} got #{views} more view(s). Now has #{total_view} total views"
+    )
+  end
+end

--- a/lib/strd_web/controllers/link_controller.ex
+++ b/lib/strd_web/controllers/link_controller.ex
@@ -12,6 +12,9 @@ defmodule StrdWeb.LinkController do
 
   def redirect_short_url(conn, %{"short_url" => short_url}) do
     link = Links.get_by_short_url!(short_url)
+
+    :telemetry.execute([:links, :short], %{views: 1}, %{short_url: short_url})
+
     redirect(conn, external: link.original)
   end
 

--- a/lib/strd_web/router.ex
+++ b/lib/strd_web/router.ex
@@ -21,6 +21,11 @@ defmodule StrdWeb.Router do
     post "/", LinkController, :create
     get "/links/:short_url", LinkController, :show
 
+    if Mix.env() in [:dev, :test] do
+      import Phoenix.LiveDashboard.Router
+      live_dashboard "/dashboard", metrics: StrdWeb.Telemetry
+    end
+
     get "/:short_url", LinkController, :redirect_short_url
   end
 
@@ -28,23 +33,6 @@ defmodule StrdWeb.Router do
   # scope "/api", StrdWeb do
   #   pipe_through :api
   # end
-
-  # Enables LiveDashboard only for development
-  #
-  # If you want to use the LiveDashboard in production, you should put
-  # it behind authentication and allow only admins to access it.
-  # If your application does not have an admins-only section yet,
-  # you can use Plug.BasicAuth to set up some basic authentication
-  # as long as you are also using SSL (which you should anyway).
-  if Mix.env() in [:dev, :test] do
-    import Phoenix.LiveDashboard.Router
-
-    scope "/" do
-      pipe_through :browser
-
-      live_dashboard "/dashboard", metrics: StrdWeb.Telemetry
-    end
-  end
 
   # Enables the Swoosh mailbox preview in development.
   #

--- a/lib/strd_web/telemetry.ex
+++ b/lib/strd_web/telemetry.ex
@@ -11,8 +11,9 @@ defmodule StrdWeb.Telemetry do
     children = [
       # Telemetry poller will execute the given period measurements
       # every 10_000ms. Learn more here: https://hexdocs.pm/telemetry_metrics
-      {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}
+      {:telemetry_poller, measurements: periodic_measurements(), period: 10_000},
       # Add reporters as children of your supervision tree.
+      Strd.Telemetry.ViewCountReporter
       # {Telemetry.Metrics.ConsoleReporter, metrics: metrics()}
     ]
 
@@ -57,7 +58,10 @@ defmodule StrdWeb.Telemetry do
       summary("vm.memory.total", unit: {:byte, :kilobyte}),
       summary("vm.total_run_queue_lengths.total"),
       summary("vm.total_run_queue_lengths.cpu"),
-      summary("vm.total_run_queue_lengths.io")
+      summary("vm.total_run_queue_lengths.io"),
+
+      # App Metrics
+      counter("links.short.views")
     ]
   end
 

--- a/lib/strd_web/templates/link/show.html.heex
+++ b/lib/strd_web/templates/link/show.html.heex
@@ -13,6 +13,11 @@
     <a href={short}><%= short %></a>
   </li>
 
+  <li>
+    <strong>Views:</strong>
+    <%= @link.view_count %>
+  </li>
+
 </ul>
 
 <span><%= link "Back", to: Routes.link_path(@conn, :index) %></span>

--- a/priv/repo/migrations/20211220141640_add_view_stats.exs
+++ b/priv/repo/migrations/20211220141640_add_view_stats.exs
@@ -1,0 +1,9 @@
+defmodule Strd.Repo.Migrations.AddViewStats do
+  use Ecto.Migration
+
+  def change do
+    alter table(:links) do
+      add :view_count, :integer, default: 0
+    end
+  end
+end

--- a/test/strd/links_test.exs
+++ b/test/strd/links_test.exs
@@ -11,6 +11,15 @@ defmodule Strd.LinksTest do
       assert Links.get_link!(link.id) == link
     end
 
+    test "increase_view_count increments view count and returns the new count" do
+      link = link_fixture()
+      assert {1, [1]} = Links.increase_view_count(link)
+      assert {1, [2]} = Links.increase_view_count(link)
+      assert {1, [7]} = Links.increase_view_count(link, 5)
+
+      assert %Link{view_count: 7} = Links.get_link!(link.id)
+    end
+
     test "create_link/1 with valid data creates a link" do
       original = "http://foo.com"
       assert {:ok, %Link{} = link} = Links.create_link(original)

--- a/test/strd/links_test.exs
+++ b/test/strd/links_test.exs
@@ -13,9 +13,9 @@ defmodule Strd.LinksTest do
 
     test "increase_view_count increments view count and returns the new count" do
       link = link_fixture()
-      assert {1, [1]} = Links.increase_view_count(link)
-      assert {1, [2]} = Links.increase_view_count(link)
-      assert {1, [7]} = Links.increase_view_count(link, 5)
+      assert {1, [1]} = Links.increase_view_count(link.short)
+      assert {1, [2]} = Links.increase_view_count(link.short)
+      assert {1, [7]} = Links.increase_view_count(link.short, 5)
 
       assert %Link{view_count: 7} = Links.get_link!(link.id)
     end

--- a/test/strd_web/controllers/link_controller_test.exs
+++ b/test/strd_web/controllers/link_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule StrdWeb.LinkControllerTest do
   use StrdWeb.ConnCase
+  alias Strd.Links
 
   @create_attrs %{original: "http://foo.com"}
 
@@ -44,6 +45,18 @@ defmodule StrdWeb.LinkControllerTest do
 
       conn = get(conn, Routes.link_path(conn, :redirect_short_url, short_url))
       assert redirected_to(conn) == @create_attrs.original
+    end
+
+    test "increases the link's view count", %{conn: conn} do
+      conn = post(conn, Routes.link_path(conn, :create), link: @create_attrs)
+      %{short_url: short_url} = redirected_params(conn)
+      link = Links.get_by_short_url!(short_url)
+      assert link.view_count == 0
+
+      # Ping the short link, get redirected, then assert the views went up by 1
+      get(conn, Routes.link_path(conn, :redirect_short_url, short_url))
+      link = Links.get_by_short_url!(short_url)
+      assert link.view_count == 1
     end
   end
 end


### PR DESCRIPTION
Increments the view count of a link when the app handles and redirects the short link.

Accomplished via a Telemetry counter to decouple event collection from the main handler logic.  Sets the stage for doing more interesting things in the custom reporter, like aggregation, piping into a time series database, or more.